### PR TITLE
chore(typo): replace `Openlist` to `OpenList`

### DIFF
--- a/pages/configuration/other.md
+++ b/pages/configuration/other.md
@@ -14,7 +14,7 @@ top: 10
 ## **Aria2** { lang="zh-CN" }
 
 ::: en
-Set Aria2 uri and Aria2 for offline download. Aria2 needs to be installed on the same server(container if use docker) as Openlist.
+Set Aria2 uri and Aria2 for offline download. Aria2 needs to be installed on the same server(container if use docker) as OpenList.
 <br/>
 :::
 ::: zh-CN

--- a/pages/ecosystem/offical_APIpage.md
+++ b/pages/ecosystem/offical_APIpage.md
@@ -1,6 +1,6 @@
 ---
-title: Openlist APIpage
-title_zh-CN: Openlist APIpage
+title: OpenList APIpage
+title_zh-CN: OpenList APIpage
 categories:
   - ecosystem
   - offical

--- a/pages/ecosystem/offical_desktop.md
+++ b/pages/ecosystem/offical_desktop.md
@@ -1,6 +1,6 @@
 ---
-title: Openlist Desktop
-title_zh-CN: Openlist Desktop
+title: OpenList Desktop
+title_zh-CN: OpenList Desktop
 categories:
   - ecosystem
   - offical

--- a/pages/ecosystem/offical_docs.md
+++ b/pages/ecosystem/offical_docs.md
@@ -1,6 +1,6 @@
 ---
-title: Openlist docs
-title_zh-CN: Openlist docs
+title: OpenList docs
+title_zh-CN: OpenList docs
 categories:
   - ecosystem
   - offical

--- a/pages/faq/error.md
+++ b/pages/faq/error.md
@@ -1,7 +1,7 @@
 ---
 # This is the title of the article
 title: OpenList Error-Code
-title_zh-CN: Openlist 错误码
+title_zh-CN: OpenList 错误码
 # This is the icon of the page
 icon: iconfont icon-state
 # This control sidebar order

--- a/pages/guide/drivers/115_open.md
+++ b/pages/guide/drivers/115_open.md
@@ -209,10 +209,10 @@ The `root folder ID` of this folder is `249163533602609229`.
 
 ```mermaid
 sequenceDiagram
-  participant  Openlist
+  participant  OpenList
   participant  115服务器
-  Openlist->>115服务器: 提供刷新令牌+内置的客户端ID和密钥
-  115服务器->>Openlist: 返回新的访问令牌+刷新令牌
+  OpenList->>115服务器: 提供刷新令牌+内置的客户端ID和密钥
+  115服务器->>OpenList: 返回新的访问令牌+刷新令牌
 ```
 
 :::
@@ -220,10 +220,10 @@ sequenceDiagram
 
 ```mermaid
 sequenceDiagram
-  participant  Openlist
+  participant  OpenList
   participant  115服务器
-  Openlist->>115服务器: 提供刷新令牌+内置的客户端ID和密钥
-  115服务器->>Openlist: 返回新的访问令牌+刷新令牌
+  OpenList->>115服务器: 提供刷新令牌+内置的客户端ID和密钥
+  115服务器->>OpenList: 返回新的访问令牌+刷新令牌
 ```
 
 :::
@@ -239,13 +239,13 @@ sequenceDiagram
 title: 如何通过OnlineAPI刷新AccessToken？
 ---
 sequenceDiagram
-  participant  Openlist
+  participant  OpenList
   participant  OnlineAPI
   participant  115服务器
-  Openlist->>OnlineAPI: 提供刷新令牌
+  OpenList->>OnlineAPI: 提供刷新令牌
   OnlineAPI->>115服务器: 提供刷新令牌+内置的客户端ID和密钥
   115服务器->>OnlineAPI: 返回新的访问令牌+刷新令牌
-  OnlineAPI->>Openlist: 返回新的访问令牌+刷新令牌
+  OnlineAPI->>OpenList: 返回新的访问令牌+刷新令牌
 ```
 
 :::
@@ -256,13 +256,13 @@ sequenceDiagram
 title: 如何通过OnlineAPI刷新AccessToken？
 ---
 sequenceDiagram
-  participant  Openlist
+  participant  OpenList
   participant  OnlineAPI
   participant  115服务器
-  Openlist->>OnlineAPI: 提供刷新令牌
+  OpenList->>OnlineAPI: 提供刷新令牌
   OnlineAPI->>115服务器: 提供刷新令牌+内置的客户端ID和密钥
   115服务器->>OnlineAPI: 返回新的访问令牌+刷新令牌
-  OnlineAPI->>Openlist: 返回新的访问令牌+刷新令牌
+  OnlineAPI->>OpenList: 返回新的访问令牌+刷新令牌
 ```
 
 :::

--- a/pages/guide/drivers/139.md
+++ b/pages/guide/drivers/139.md
@@ -76,7 +76,7 @@ Fill in the content starting after the Basic and a space, **do not include Basic
 ## **类型** { lang="zh-CN" }
 
 ::: en
-Openlist currently supports 4 types of cloud storage:
+OpenList currently supports 4 types of cloud storage:
 
 - Personal New: New API
   - Note: The account has been migrated to a new personal cloud by the end of 2024
@@ -90,7 +90,7 @@ Openlist currently supports 4 types of cloud storage:
   <br/>
   :::
   ::: zh-CN
-  Openlist 目前支持挂载 4 种类型：
+  OpenList 目前支持挂载 4 种类型：
 - 新个人云：新 API
   - 注意：移动已于 2024 年底迁移账号到新的个人云
   - 新的个人云使用 PUT 方法直连 EOS 分片上传

--- a/pages/guide/drivers/baidu.md
+++ b/pages/guide/drivers/baidu.md
@@ -89,13 +89,13 @@ flowchart TB
 **Currently, there are three methods to obtain a Baidu Netdisk refresh token:**
 
 - All methods require you to [click here](https://api.oplist.org/) to obtain the refresh token. The **first method** requires developer permissions, while the **latter two** do not.
-  - **1.** If you have Baidu Netdisk developer permissions, please select **"Baidu Netdisk Auth Login"**, and in the Baidu Netdisk developer app backend, set the callback URL to the one provided on the webpage. After clicking "Get Token," you will automatically receive a refresh token. You can then configure your own `client_id` and `client_secret` in Openlist.  
+  - **1.** If you have Baidu Netdisk developer permissions, please select **"Baidu Netdisk Auth Login"**, and in the Baidu Netdisk developer app backend, set the callback URL to the one provided on the webpage. After clicking "Get Token," you will automatically receive a refresh token. You can then configure your own `client_id` and `client_secret` in OpenList.  
     ![](/img/drivers/baidu/dev_token.png)
-  - **2.** This method uses a built-in API call via our intermediary server to refresh the access token. It is already available online. Simply check the option to use the parameters provided by Openlist, click "Get Token," and you will receive a refresh token. In the storage configuration page of Openlist, enable the "Use Online API" option, and enter the refresh token to start using it.  
+  - **2.** This method uses a built-in API call via our intermediary server to refresh the access token. It is already available online. Simply check the option to use the parameters provided by OpenList, click "Get Token," and you will receive a refresh token. In the storage configuration page of OpenList, enable the "Use Online API" option, and enter the refresh token to start using it.  
     ![](/img/drivers/baidu/non_dev_token.png)  
     The basic principle of the online API is illustrated in the diagram below:  
     ![](/img/drivers/baidu/openapi.png)
-  - **3.** If you do not have Baidu Netdisk developer permissions but somehow have access to an app’s `client_id` and `client_secret`, please select **"Baidu Netdisk OOB Authentication"**. By default, this method uses the client parameters from the "ES File Explorer" app, but you can also input your own `client_id` and `client_secret`. After clicking "Get Token," wait patiently as you are redirected to the Baidu authorization page. Log in and authorize the app, then copy the authorization code and return to the original webpage to input the code as instructed to obtain the refresh token. In the storage configuration page of Openlist, fill in the `client_id` and `client_secret` to start using the service.  
+  - **3.** If you do not have Baidu Netdisk developer permissions but somehow have access to an app’s `client_id` and `client_secret`, please select **"Baidu Netdisk OOB Authentication"**. By default, this method uses the client parameters from the "ES File Explorer" app, but you can also input your own `client_id` and `client_secret`. After clicking "Get Token," wait patiently as you are redirected to the Baidu authorization page. Log in and authorize the app, then copy the authorization code and return to the original webpage to input the code as instructed to obtain the refresh token. In the storage configuration page of OpenList, fill in the `client_id` and `client_secret` to start using the service.  
      ![](/img/drivers/baidu/crack_dev_token.png)
 
 :::
@@ -106,11 +106,11 @@ flowchart TB
 - 全部都要[点击这里](https://api.oplist.org/) 来获取刷新令牌。第一种需要开发者权限，后**两种**不需要。
   - **1**、如果你有百度网盘开发者权限，请选择“百度网盘 验证登录”，并在百度网盘开发者应用后台里填入配置回调地址为该网页提供的回调地址。点击获取token后即可自动获取刷新令牌，并在openlist中配置您自己的cilent_id和cilent_secret。
     ![](/img/drivers/baidu/dev_token.png)
-  - **2**、内置API调用的实现方式，利用我们建立的服务器中转刷新access_token，目前已经上线，勾选使用Openlist提供的参数，点击获取token即可获得刷新令牌。在Openlist的存储配置界面，打开使用online api选项，经刷新令牌填入即可使用。
+  - **2**、内置API调用的实现方式，利用我们建立的服务器中转刷新access_token，目前已经上线，勾选使用OpenList提供的参数，点击获取token即可获得刷新令牌。在OpenList的存储配置界面，打开使用online api选项，经刷新令牌填入即可使用。
     ![](/img/drivers/baidu/non_dev_token.png)
     对于online api的原理，大体可以由下图说明：
     ![](/img/drivers/baidu/openapi.png)
-  - **3**、如果你没有百度网盘开发权限，但是你又莫名其妙的掌握有某个APP的id和secret，请选择“百度网盘 OOB验证”，目前默认使用es文件浏览器的客户端参数进行配置，您也可以选择使用自己的获取到的cilent_id和cilent_secret参数，点击获取token后耐心等待跳转百度页面，登录授权后复制授权码，回到原网页按照提示即可获取刷新令牌。在Openlist的存储配置界面将cilent_id和cilent_secret填入即可使用。
+  - **3**、如果你没有百度网盘开发权限，但是你又莫名其妙的掌握有某个APP的id和secret，请选择“百度网盘 OOB验证”，目前默认使用es文件浏览器的客户端参数进行配置，您也可以选择使用自己的获取到的cilent_id和cilent_secret参数，点击获取token后耐心等待跳转百度页面，登录授权后复制授权码，回到原网页按照提示即可获取刷新令牌。在OpenList的存储配置界面将cilent_id和cilent_secret填入即可使用。
     ![](/img/drivers/baidu/crack_dev_token.png)
 
 :::

--- a/pages/guide/drivers/dropbox.md
+++ b/pages/guide/drivers/dropbox.md
@@ -48,8 +48,8 @@ Dropbox官网：https://www.dropbox.com/
   - Finally, go to the permissions configuration page to set the app's permissions.
     ![Permission configuration](/img/drivers/dropbox/4.png)
   - [Click here](https://api.oplist.org/) to enter the token acquisition tool. Select Dropbox, fill in your id and secret, and after authorization you can get the refresh token.
-  - In the Openlist configuration page, enter the refresh token, id, and secret to use. Note that the refresh token is about 40-50 characters long.
-    ![Openlist configuration](/img/drivers/dropbox/5.png)
+  - In the OpenList configuration page, enter the refresh token, id, and secret to use. Note that the refresh token is about 40-50 characters long.
+    ![OpenList configuration](/img/drivers/dropbox/5.png)
   - If you are highly privacy-conscious, Dropbox supports local callback. You can use the following script provided by GPT to quickly implement it, communicating only with Dropbox servers.
   - **Note: Since the callback address is local and you have not set up a real local callback server, please manually copy the authorization code from the browser address bar.**
   - **Please resolve Python environment issues yourself, or use the callback server provided above.**
@@ -106,7 +106,7 @@ Dropbox官网：https://www.dropbox.com/
   - 最后，进入权限配置界面，配置app的权限
     ![权限配置](/img/drivers/dropbox/4.png)
   - [点击这里](https://api.oplist.org/)进入token获取工具，选择dropbox后填入自己的id和secret，完成授权后可以获得刷新令牌。
-  - 在Openlist配置界面，填入刷新令牌、id和secret即可使用，注意刷新令牌的长度大致为40-50个字符。
+  - 在OpenList配置界面，填入刷新令牌、id和secret即可使用，注意刷新令牌的长度大致为40-50个字符。
     ![openlist配置](/img/drivers/dropbox/5.png)
   - 如果你有强烈的隐私意识，dropbox支持本地回调，可以使用以下全程由GPT提供的脚本快速实现，只和dropbox的服务器进行通信。
   - **注意：由于回调地址是本地，而你并没有建立真正的本地回调服务器，所以请自己从浏览器地址栏获取返回的权限码**

--- a/pages/guide/drivers/google_drive.md
+++ b/pages/guide/drivers/google_drive.md
@@ -130,10 +130,10 @@ categories:
 
 ```mermaid
 sequenceDiagram
-  participant  Openlist
+  participant  OpenList
   participant  GoogleDrive
-  Openlist->>GoogleDrive: 提供刷新令牌+内置的客户端ID和密钥
-  GoogleDrive->>Openlist: 返回新的访问令牌+刷新令牌
+  OpenList->>GoogleDrive: 提供刷新令牌+内置的客户端ID和密钥
+  GoogleDrive->>OpenList: 返回新的访问令牌+刷新令牌
 
 ```
 
@@ -144,13 +144,13 @@ sequenceDiagram
 title: 如何通过OnlineAPI刷新AccessToken？
 ---
 sequenceDiagram
-  participant  Openlist
+  participant  OpenList
   participant  OnlineAPI
   participant  GoogleDrive
-  Openlist->>OnlineAPI: 提供刷新令牌
+  OpenList->>OnlineAPI: 提供刷新令牌
   OnlineAPI->>GoogleDrive: 提供刷新令牌+内置的客户端ID和密钥
   GoogleDrive->>OnlineAPI: 返回新的访问令牌+刷新令牌
-  OnlineAPI->>Openlist: 返回新的访问令牌+刷新令牌
+  OnlineAPI->>OpenList: 返回新的访问令牌+刷新令牌
 ```
 
 ## 5.默认使用的哪种下载方式？

--- a/pages/guide/drivers/onedrive.md
+++ b/pages/guide/drivers/onedrive.md
@@ -43,7 +43,7 @@ categories:
 - 首先打开 [这里](https://api.oplist.org/)，根据自己的账户选择对应的Onedrive版本。
 - 勾选“使用 OpenList 提供的参数”，点击“获取Token”后登录需要挂载的OneDrive账号，授权后返回页面即可获得刷新令牌。
  ![在线Token获取工具](/img/drivers/OneDrive/online_api.png)
-- 前往Openlist的存储管理界面选择OneDrive驱动，勾选使用在线api，填入刷新令牌后即可挂载
+- 前往OpenList的存储管理界面选择OneDrive驱动，勾选使用在线api，填入刷新令牌后即可挂载
  ![后端配置界面](/img/drivers/OneDrive/online_api_config.png)
 :::
 

--- a/pages/guide/drivers/s3.md
+++ b/pages/guide/drivers/s3.md
@@ -196,7 +196,7 @@ Add filename to Content-Disposition header.
 :::
 ::: en
 ::: tip
-Openlist needs to skip `referer` to mount **Alibaba Cloud Disk**. If you do not allow `referer` to be empty in anti-leech, it will not work, because Alibaba Cloud Disk uses Alibaba Cloud OSS (in Beijing area)
+OpenList needs to skip `referer` to mount **Alibaba Cloud Disk**. If you do not allow `referer` to be empty in anti-leech, it will not work, because Alibaba Cloud Disk uses Alibaba Cloud OSS (in Beijing area)
 In fact, the `Region|Region` option can be written as `Endpoint`, but for the sake of specification, let’s write it according to the comparison table.:::
 :::
 ::: zh-CN
@@ -205,7 +205,7 @@ In fact, the `Region|Region` option can be written as `Endpoint`, but for the sa
 :::
 ::: zh-CN
 ::: tip
-Openlist 挂载**阿里云盘**需要跳过 `referer` ，若你在防盗链开启不允许 `referer` 为空的话会无法使用，因为阿里云盘用的就是阿里云OSS（北京地区的）
+OpenList 挂载**阿里云盘**需要跳过 `referer` ，若你在防盗链开启不允许 `referer` 为空的话会无法使用，因为阿里云盘用的就是阿里云OSS（北京地区的）
 其实 `地区|Region` 选项写 `Endpoint` 一样的也可以用，但是为了规范还是照着对照表写吧。
 :::
 ::: en
@@ -531,7 +531,7 @@ You can see Endpoint and Access Key on this page, you need to select an account 
 ![Google Cloud](/img/drivers/s3/googleStorage2.png)
 Access Key/Secret will be displayed on the new page, They will only be displayed this time. Please save them properly.
 ![Google Cloud](/img/drivers/s3/googleStorage3.png)
-At this point, the EndPoint, access key Id, and security access key required by Openlist have been obtained. Please view the remaining buckets and regions in the corresponding buckets.
+At this point, the EndPoint, access key Id, and security access key required by OpenList have been obtained. Please view the remaining buckets and regions in the corresponding buckets.
 ![Google Cloud](/img/drivers/s3/googleStorage4.png)
 <br/>
 :::
@@ -544,9 +544,9 @@ At this point, the EndPoint, access key Id, and security access key required by 
 ![Google Cloud](/img/drivers/s3/googleStorage1.png)
 在这个页面我们可以很明显的看到 Endpoint 和 Access Key，我这里因为已经创建的有一个AK/SK了，如果你没有，直接点下面的创建即可，点了创建，会提示你执行账户，我这因为账号问题，有两个，正常情况下只有一个，你选了账户后，点创建
 ![Google Cloud](/img/drivers/s3/googleStorage2.png)
-然后就会出现Access Key/Secret 了，它俩分别对应Openlist的 访问密钥 Id 和 安全访问密钥，这个只显示一次，一定要复制并保存到本地
+然后就会出现Access Key/Secret 了，它俩分别对应OpenList的 访问密钥 Id 和 安全访问密钥，这个只显示一次，一定要复制并保存到本地
 ![Google Cloud](/img/drivers/s3/googleStorage3.png)
-到这里，Openlist所需要的 EndPoint 、访问密钥 Id、安全访问密钥 就获取到了，剩余的 存储桶和地区，请在存储桶里面查看
+到这里，OpenList所需要的 EndPoint 、访问密钥 Id、安全访问密钥 就获取到了，剩余的 存储桶和地区，请在存储桶里面查看
 ![Google Cloud](/img/drivers/s3/googleStorage4.png)
 <br/>
 :::

--- a/pages/guide/installation/manual.md
+++ b/pages/guide/installation/manual.md
@@ -426,5 +426,5 @@ openlist restart
 Download the new version of OpenList and replace the previous one.
 :::
 ::: zh-CN
-下载新版Openlist，把之前的替换了即可。
+下载新版OpenList，把之前的替换了即可。
 :::


### PR DESCRIPTION
- Uniform the case of 'OpenList' across the documents.
- Avoid documents that look "unofficial".