### PR TITLE
fix(ensure-full-git): use execSync

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "lint-staged": "^16.1.2",
     "nodemon": "^3.1.10",
     "prettier": "^3.6.2",
-    "simple-git": "^3.28.0",
     "vite": "6.3.5",
     "vitepress": "1.1.4",
     "vue": "^3.5.17",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,9 +74,6 @@ importers:
       prettier:
         specifier: ^3.6.2
         version: 3.6.2
-      simple-git:
-        specifier: ^3.28.0
-        version: 3.28.0
       vite:
         specifier: 6.3.5
         version: 6.3.5(@types/node@24.0.13)(jiti@2.4.2)(sass@1.89.2)(terser@5.43.1)(yaml@2.8.0)

--- a/utils/ensure-full-git.js
+++ b/utils/ensure-full-git.js
@@ -1,8 +1,6 @@
 #!/usr/bin/env node
+import { execSync } from 'child_process'
 import { existsSync } from 'fs'
-import simpleGit from 'simple-git'
-
-const git = simpleGit()
 
 /**
  * Restores complete Git history for shallow clones to fix contributor tracking issues.
@@ -15,17 +13,16 @@ async function checkAndRestoreHistory() {
     }
 
     // Detect if repository is a shallow clone
-    const isShallow = await git.raw('rev-parse', '--is-shallow-repository')
+    const isShallow = execSync('git rev-parse --is-shallow-repository').toString().trim() === 'true'
 
-    if (isShallow.trim() === 'true') {
+    if (isShallow) {
       console.log('➤ Detected shallow clone. Trying to fetch full history for current branch...')
 
       // Get current branch name
-      const branch = await git.branch()
-      const currentBranch = branch.current
+      const currentBranch = execSync('git rev-parse --abbrev-ref HEAD').toString().trim()
 
       // Fetch complete history for current branch only
-      await git.raw('fetch', '--unshallow', 'origin', currentBranch)
+      execSync(`git fetch --unshallow origin ${currentBranch}`, { stdio: 'inherit' })
       console.log(`✓ Full history restored for branch: ${currentBranch}`)
     } else {
       console.log('✓ Repository already has complete history')


### PR DESCRIPTION
由于 simple-git 读取 git ref 存在问题，改用 execSync 调用 git cli 实现

![](https://github.com/user-attachments/assets/7da535ad-ef6b-4e98-9f75-129bf1c0c265)


![](https://github.com/user-attachments/assets/b8037442-b2c2-4421-a5a3-210d8bab340f)
