### PR TITLE
docs(openlist_releases): add more details to LoongArch64 packages

### DIFF
--- a/components/openlist_releases.json
+++ b/components/openlist_releases.json
@@ -339,16 +339,16 @@
     "filename": "openlist-linux-musl-loong64-lite.tar.gz",
     "os": "Linux (musl)",
     "cpu": "LoongArch 64",
-    "desc": "Lite version for LoongArch 64 Linux systems with musl libc",
-    "desc_cn": "龙芯LoongArch 64 musl libc Linux系统的精简版",
+    "desc": "Lite version for LoongArch 64 Linux systems with musl libc and ABI2.0",
+    "desc_cn": "龙芯LoongArch 64 musl libc Linux ABI2.0 系统的精简版",
     "link": "https://github.com/OpenListTeam/OpenList/releases/latest/download/openlist-linux-musl-loong64-lite.tar.gz"
   },
   {
     "filename": "openlist-linux-musl-loong64.tar.gz",
     "os": "Linux (musl)",
     "cpu": "LoongArch 64",
-    "desc": "For LoongArch 64 Linux systems with musl libc",
-    "desc_cn": "用于龙芯LoongArch 64 musl libc Linux系统",
+    "desc": "For LoongArch 64 Linux systems with musl libc and ABI2.0",
+    "desc_cn": "用于龙芯LoongArch 64 musl libc Linux ABI2.0 系统",
     "link": "https://github.com/OpenListTeam/OpenList/releases/latest/download/openlist-linux-musl-loong64.tar.gz"
   },
   {


### PR DESCRIPTION
OpenList编译出来的二进制文件仅适用于 ABI2.0，参见, https://areweloongyet.com/docs/old-and-new-worlds/

鉴于目前有不少存量用户仍在使用基于`ABI1.0`的旧世界系统，因此，有必要在下载链接处添加合适的提示词。