### PR TITLE
docs(openlist_releases_db): add entries for loongarch64 releases

### DIFF
--- a/components/openlist_releases_db.json
+++ b/components/openlist_releases_db.json
@@ -304,7 +304,7 @@
     "lite": false
   },
   {
-    "filename": "penlist-linux-loong64.tar.gz",
+    "filename": "openlist-linux-loong64.tar.gz",
     "os": "Linux",
     "cpu": "LoongArch 64",
     "desc": "For LoongArch 64 Linux systems using ABI2.0 (new world)",


### PR DESCRIPTION
需要注意的是，目前openlist-linux-loong64-abi1.0.tar.gz与openlist-linux-loong64.tar.gz仅在beta版本中提供，暂未添加到stable中（因为尚未修改build.sh)