### PR TITLE
docs(guide): add missing step in Docker installation guide

### DIFF
--- a/pages/guide/installation/docker.md
+++ b/pages/guide/installation/docker.md
@@ -48,6 +48,7 @@ Create `docker-compose.yml` file.
 
 ```bash
 mkdir -p /opt/openlist
+cd /opt/openlist
 vim docker-compose.yml
 ```
 


### PR DESCRIPTION
Docker Compose 文档少了个 cd