### PR TITLE
docs(faq): add disable 189Cloud Device Lock

### DIFF
--- a/pages/faq/howto.md
+++ b/pages/faq/howto.md
@@ -157,10 +157,10 @@ Permissions of this strongest copyleft license are conditioned on making availab
 ## 添加 189 云存储时：设备 ID 不存在，需要二次设备验证 ​ { lang="zh-CN" }
 
 :::en
-Open the Tianyi Account website at https://e.dlife.cn/index.do, log in, and then disable the Device Lock..
+Open the Tianyi Account website at <https://e.dlife.cn/index.do>, log in, and then disable the Device Lock..
 :::
 :::zh-CN
-打开天翼账号网站https://e.dlife.cn/index.do登陆后关掉设备锁即可。
+打开天翼账号网站 <https://e.dlife.cn/index.do>，登陆后关掉设备锁即可。
 :::
 
 ## When adding Tianyi cloud disk client storage: prompt need img validate code: verification code { lang="en" }


### PR DESCRIPTION
When adding 189Cloud Storage, if an error message "the device ID does not exist, and a secondary device verification is required" appears, the incorrect solution for this error has been updated to the correct one, which has been verified successfully by multiple users including myself. Currently, the only way to disable the Device Lock is by logging into the Tianyi Account website; no other methods have been found so far. 将添加"189云存储时显示设备ID不存在需要二次设备验证"的报错,中的错误解答更改为正确的,已经有包括我在内多名用户验证成功.目前设备锁也只有通过登录天翼账号的网站可以关掉,暂未发现其他方法.