### PR TITLE
fix: correct 189 Cloud link order

### DIFF
--- a/pages/faq/howto.md
+++ b/pages/faq/howto.md
@@ -154,7 +154,7 @@ Permissions of this strongest copyleft license are conditioned on making availab
 
 ## When adding a 189 Cloud storage: the device ID does not exist, and a secondary device verification is required​ { lang="en" }
 
-## 添加 天翼云盘 云存储时：设备 ID 不存在，需要二次设备验证 ​ { lang="zh-CN" }
+## 添加 天翼云盘 云存储时：设备 ID 不存在，需要二次设备验证 ​{ lang="zh-CN" }
 
 :::en
 Open the Tianyi Account website at <https://e.dlife.cn/index.do>, log in, and then disable the Device Lock..

--- a/pages/faq/howto.md
+++ b/pages/faq/howto.md
@@ -154,7 +154,7 @@ Permissions of this strongest copyleft license are conditioned on making availab
 
 ## When adding a 189 Cloud storage: the device ID does not exist, and a secondary device verification is required​ { lang="en" }
 
-## 添加 天翼云盘 云存储时：设备 ID 不存在，需要二次设备验证 ​{ lang="zh-CN" }
+## 添加 天翼云盘 云存储时：设备 ID 不存在，需要二次设备验证 { lang="zh-CN" }
 
 :::en
 Open the Tianyi Account website at <https://e.dlife.cn/index.do>, log in, and then disable the Device Lock..

--- a/pages/guide/drivers/189.md
+++ b/pages/guide/drivers/189.md
@@ -193,7 +193,7 @@ Video reference: **https://www.bilibili.com/video/BV16A4y197De**
 It is recommended to use the 189 Cloud PC first, [**Notes click to view.**](../../faq/howto.md#when-adding-a-189-cloud-storage-the-device-id-does-not-exist-and-a-secondary-device-verification-is-required)
 :::
 ::: zh-CN
-建议首选使用天翼云盘客户端，[**注意事项点击查看**](../../faq/howto.md#添加-天翼云盘-云存储时设备-id-不存在需要二次设备验证)
+建议首选使用天翼云盘客户端，[**注意事项点击查看**](../../faq/howto.md#-天翼云盘-云存储时-设备-id-不存在-需要二次设备验证-)
 :::
 
 ### 默认使用的下载方式 { lang="zh-CN" }

--- a/pages/guide/drivers/189.md
+++ b/pages/guide/drivers/189.md
@@ -190,10 +190,10 @@ Video reference: **https://www.bilibili.com/video/BV16A4y197De**
 ## suggestion { lang="en" }
 
 ::: en
-It is recommended to use the 189 Cloud PC first, [**Notes click to view.**](../../faq/howto#when-adding-189-cloud-pc-storage-prompt-need-img-validate-code-verification-code)
+It is recommended to use the 189 Cloud PC first, [**Notes click to view.**](../../faq/howto.md#when-adding-a-189-cloud-storage-the-device-id-does-not-exist-and-a-secondary-device-verification-is-required)
 :::
 ::: zh-CN
-建议首选使用天翼云盘客户端，[**注意事项点击查看**](../../faq/howto.md#添加-天翼云盘客户端-存储时-提示-need-img-validate-code-验证码)
+建议首选使用天翼云盘客户端，[**注意事项点击查看**](../../faq/howto.md#添加-天翼云盘-云存储时设备-id-不存在需要二次设备验证)
 :::
 
 ### 默认使用的下载方式 { lang="zh-CN" }

--- a/pages/guide/drivers/189.md
+++ b/pages/guide/drivers/189.md
@@ -198,7 +198,7 @@ Video reference: **https://www.bilibili.com/video/BV16A4y197De**
 It is recommended to use the 189 Cloud PC first, [**Notes click to view.**](../../faq/howto.md#when-adding-a-189-cloud-storage-the-device-id-does-not-exist-and-a-secondary-device-verification-is-required)
 :::
 ::: zh-CN
-建议首选使用天翼云盘客户端，[**注意事项点击查看**](../../faq/howto.md#添加-天翼云盘-云存储时-设备-id-不存在-需要二次设备验证-)
+建议首选使用天翼云盘客户端，[**注意事项点击查看**](../../faq/howto.md#添加-天翼云盘-云存储时-设备-id-不存在-需要二次设备验证)
 :::
 
 ### 默认使用的下载方式 { lang="zh-CN" }

--- a/pages/guide/drivers/189.md
+++ b/pages/guide/drivers/189.md
@@ -193,7 +193,7 @@ Video reference: **https://www.bilibili.com/video/BV16A4y197De**
 It is recommended to use the 189 Cloud PC first, [**Notes click to view.**](../../faq/howto.md#when-adding-a-189-cloud-storage-the-device-id-does-not-exist-and-a-secondary-device-verification-is-required)
 :::
 ::: zh-CN
-建议首选使用天翼云盘客户端，[**注意事项点击查看**](../../faq/howto.md#-天翼云盘-云存储时-设备-id-不存在-需要二次设备验证-)
+建议首选使用天翼云盘客户端，[**注意事项点击查看**](../../faq/howto.md#添加-天翼云盘-云存储时设备-id-不存在需要二次设备验证-)
 :::
 
 ### 默认使用的下载方式 { lang="zh-CN" }

--- a/pages/guide/drivers/189.md
+++ b/pages/guide/drivers/189.md
@@ -193,7 +193,7 @@ Video reference: **https://www.bilibili.com/video/BV16A4y197De**
 It is recommended to use the 189 Cloud PC first, [**Notes click to view.**](../../faq/howto.md#when-adding-a-189-cloud-storage-the-device-id-does-not-exist-and-a-secondary-device-verification-is-required)
 :::
 ::: zh-CN
-建议首选使用天翼云盘客户端，[**注意事项点击查看**](../../faq/howto.md#添加-天翼云盘-云存储时设备-id-不存在需要二次设备验证-)
+建议首选使用天翼云盘客户端，[**注意事项点击查看**](../../faq/howto.md#添加-天翼云盘-云存储时-设备-id-不存在-需要二次设备验证-)
 :::
 
 ### 默认使用的下载方式 { lang="zh-CN" }


### PR DESCRIPTION
The original link jumped directly to the "need img validate code" issue (second note),  bypassing the primary solution for "device ID does not exist" (first note).  Updated the link to point to the initial troubleshooting step to ensure users  address the root cause before proceeding to subsequent issues.