### PR TITLE
docs(drivers): update 139Yun driver guide

### DIFF
--- a/pages/guide/drivers/139.md
+++ b/pages/guide/drivers/139.md
@@ -297,7 +297,7 @@ In Firefox, cookies and local storage can be easier to find in DevTools -> Stora
 | 旧个人云文件夹 ID | `getDisk` 请求或响应                   | `catalogID`                                          |
 | `UserDomainID`    | 浏览器 Cookie                          | `ud_id`                                              |
 
-Firefox 中可以在开发者工具 -> 存储中查看 Cookie 和本地存储，通常更容易找到 `authorization`、`ud_id` 和 `currentCatalogID`。
+Firefox 中可以在开发者工具 -> 存储中查看 Cookie 和本地存储，通常更容易找到 `Authorization`、`ud_id` 和 `currentCatalogID`。
 :::
 
 ### Personal new { lang="en" }

--- a/pages/guide/drivers/139.md
+++ b/pages/guide/drivers/139.md
@@ -22,29 +22,29 @@ Cloud disk address: **<https://yun.139.com/>**
 云盘地址：**<https://yun.139.com/>**
 :::
 
-::: en
+:::: en
 ::: warning
 The OpenList version must be greater than `v3.41.0` to use this tutorial.
 :::
-:::
+::::
 
-::: zh-CN
+:::: zh-CN
 ::: warning
 OpenList 版本必须大于 `v3.41.0` 才能使用本教程。
 :::
-:::
+::::
 
-::: en
+:::: en
 ::: tip
 Most parameters can be obtained from browser DevTools. See [Search keywords](#search-keywords).
 :::
-:::
+::::
 
-::: zh-CN
+:::: zh-CN
 ::: tip
 大部分参数可通过浏览器开发者工具获取。请参考[搜索关键词](#搜索关键词)。
 :::
-:::
+::::
 
 ## Quick start { lang="en" }
 
@@ -154,17 +154,17 @@ OpenList 目前支持四种中国移动云盘类型，默认类型是 `personal_
 
 :::
 
-::: en
+:::: en
 ::: warning
 After changing `Type`, clear or update `Root folder ID`, then save the storage again.
 :::
-:::
+::::
 
-::: zh-CN
+:::: zh-CN
 ::: warning
 更改 `Type` 后，请清空或重新填写 `Root folder ID`，再保存存储。
 :::
-:::
+::::
 
 ## Root folder ID { lang="en" }
 
@@ -333,7 +333,7 @@ If you want the folder ID of a subfolder, enter that subfolder first and then in
 
 ### 家庭云 { lang="zh-CN" }
 
-::: en
+:::: en
 ![](/img/drivers/139/other-family.png)
 ![](/img/drivers/139/ch-family.png)
 
@@ -342,9 +342,9 @@ Although the video is for V2, the method for obtaining folder ID and Cloud ID is
 
 **<https://www.bilibili.com/video/BV1US4y1w79a>**
 :::
-:::
+::::
 
-::: zh-CN
+:::: zh-CN
 ![](/img/drivers/139/other-family.png)
 ![](/img/drivers/139/ch-family.png)
 
@@ -353,7 +353,7 @@ Although the video is for V2, the method for obtaining folder ID and Cloud ID is
 
 **<https://www.bilibili.com/video/BV1US4y1w79a>**
 :::
-:::
+::::
 
 ### OpenList fill in examples { lang="en" }
 
@@ -391,9 +391,15 @@ The default download method is 302 redirection. If a player such as PotPlayer ca
 title: Which download method is used by default?
 ---
 flowchart TB
-    a1[302 redirect]====|default|a2[user device]
-    c1[local proxy]-.alternative.->a2
-    b1[download proxy URL]-.alternative.->a2
+    style a1 fill:#bbf,stroke:#f66,stroke-width:2px,color:#fff
+    style a2 fill:#ff7575,stroke:#333,stroke-width:4px
+    subgraph ide1 [ ]
+    a1
+    end
+    a1[302]:::someclass====|default|a2[user equipment]
+    classDef someclass fill:#f96
+    c1[local proxy]-.alternative.->a2[user equipment]
+    b1[Download proxy URL]-.alternative.->a2[user equipment]
     click a1 "../drivers/common.html#webdav-policy"
     click b1 "../drivers/common.html#webdav-policy"
     click c1 "../drivers/common.html#webdav-policy"
@@ -409,9 +415,15 @@ flowchart TB
 title: 默认使用的哪种下载方式？
 ---
 flowchart TB
-    a1[302 跳转]====|默认|a2[用户设备]
-    c1[本机代理]-.备选.->a2
-    b1[代理 URL]-.备选.->a2
+    style a1 fill:#bbf,stroke:#f66,stroke-width:2px,color:#fff
+    style a2 fill:#ff7575,stroke:#333,stroke-width:4px
+    subgraph ide1 [ ]
+    a1
+    end
+    a1[302]:::someclass====|默认|a2[用户设备]
+    classDef someclass fill:#f96
+    c1[本机代理]-.备选.->a2[用户设备]
+    b1[代理URL]-.备选.->a2[用户设备]
     click a1 "../drivers/common.html#webdav-策略"
     click b1 "../drivers/common.html#webdav-策略"
     click c1 "../drivers/common.html#webdav-策略"

--- a/pages/guide/drivers/139.md
+++ b/pages/guide/drivers/139.md
@@ -17,61 +17,113 @@ categories:
 ::: en
 Cloud disk address: **<https://yun.139.com/>**
 :::
-::: en
-::: warning
-The openlist version must be greater than `v3.41.0` to use this tutorial.
-:::
-::: en
-::: tip
-Parameters can be obtained from the browser DevTools -> Network by [searching keywords](#search-keywords).
-:::
 
 ::: zh-CN
 云盘地址：**<https://yun.139.com/>**
 :::
+
+::: en
+::: warning
+The OpenList version must be greater than `v3.41.0` to use this tutorial.
+:::
+:::
+
 ::: zh-CN
 ::: warning
-OpenList版本必须大于 `v3.41.0` 版本才能使用本教程！
+OpenList 版本必须大于 `v3.41.0` 才能使用本教程。
 :::
+:::
+
+::: en
+::: tip
+Most parameters can be obtained from browser DevTools. See [Search keywords](#search-keywords).
+:::
+:::
+
 ::: zh-CN
 ::: tip
-相关参数可通过 浏览器开发工具 -> 网络 -> 请求 [搜索关键词](#搜索关键词)获取！
+大部分参数可通过浏览器开发者工具获取。请参考[搜索关键词](#搜索关键词)。
+:::
 :::
 
-## Proxy Range { lang="en" }
+## Quick start { lang="en" }
 
-## 代理 Range { lang="zh-CN" }
+## 快速开始 { lang="zh-CN" }
 
 ::: en
-You need to enable `Web Proxy` or`WebDAV Native Proxy` first.
-After enabling this option, it can resolve some issues caused by server not returning the correct HTTP status codes
-even when a proxy is enabled, such as videos being unable to play, lack of support for resumable downloads, etc.
-<br/>
-:::
-::: zh-CN
-需要先启用 `Web 代理` 或者 `WebDAV 本地代理` 才会生效。
-开启这个选项后，可解决即使开启代理但下载链接没有返回正确的 HTTP 状态码导致的一些问题，例如视频无法播放、不支持断点续传等问题。
-<br/>
-:::
+For long-term use, use the new personal cloud with password login fallback. This lets OpenList persist the generated `Authorization` and renew it automatically when possible.
 
-## Authorization { lang="en" }
+1. Log in to <https://mail.10086.cn/> in your browser.
+2. Copy cookies from `mail.10086.cn` and paste them into `MailCookies` as a Cookie Header String, for example `key1=value1; key2=value2`. Do not paste JSON, a table, or one cookie per line.
+3. Fill your 139 email/mobile account in `Username`, and fill the corresponding password in `Password`.
+4. Add a `139Yun` storage in OpenList and fill:
+   - `Type`: `personal_new`
+   - `MailCookies`: the cookies copied in step 2
+   - `Username`: your account
+   - `Password`: your password
+   - `Root folder ID`: leave empty or fill `/` for the root directory
+5. Leave `Authorization`, `Cloud ID`, and `UserDomainID` empty.
+6. Save the storage.
 
-## Authorization { lang="zh-CN" }
+If you only want to mount quickly, you can fill only `Authorization`: log in to <https://yun.139.com/>, find a `hcy/file/list` request in DevTools -> Network, copy the request header `Authorization`, and paste only the content after `Basic `.
 
-::: en
-Update the method of authentication, please get `Authorization` to fill in
-:::
-::: en
-::: warning
-Fill in the content starting after the Basic and a space, **do not include Basic**!
+If you want to mount a subfolder, enter that folder on the 139Yun website first, then use the current `parentFileId` or `currentCatalogID` as `Root folder ID`.
 :::
 
 ::: zh-CN
-已更换鉴权方式，请获取 `Authorization` 进行填写。
+长期使用推荐按“新个人云 + 账号密码回退登录”配置。这样 OpenList 可以持久化生成的 `Authorization`，并在可行时自动续期。
+
+1. 在浏览器登录 <https://mail.10086.cn/>。
+2. 复制 `mail.10086.cn` 的 Cookie，以 Cookie Header String 格式粘贴到 `MailCookies`，例如 `key1=value1; key2=value2`。不要粘贴 JSON、表格，也不要一行一个 Cookie。
+3. 在 `Username` 填写 139 邮箱/手机号账号，在 `Password` 填写对应密码。
+4. 在 OpenList 添加 `139Yun` 存储，并填写：
+   - `Type`：`personal_new`
+   - `MailCookies`：第 2 步复制的 Cookie
+   - `Username`：你的账号
+   - `Password`：你的密码
+   - `Root folder ID`：挂载根目录时留空或填写 `/`
+5. `Authorization`、`Cloud ID`、`UserDomainID` 先留空。
+6. 保存存储。
+
+如果只是想快速挂载，也可以只填 `Authorization`：登录 <https://yun.139.com/>，在开发者工具 -> 网络中找到 `hcy/file/list` 请求，复制请求标头里的 `Authorization`，并且只粘贴 `Basic ` 后面的内容。
+
+如果要挂载子文件夹，请先在移动云盘网页端进入该文件夹，再把当前的 `parentFileId` 或 `currentCatalogID` 填到 `Root folder ID`。
 :::
+
+## Authentication { lang="en" }
+
+## 鉴权方式 { lang="zh-CN" }
+
+::: en
+The driver supports three authentication methods. Use only one method unless you need password login as a fallback.
+
+| Method                  | Fields to fill                        | Notes                                                                                                                                                                                                                                     |
+| ----------------------- | ------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Password login fallback | `MailCookies`, `Username`, `Password` | Recommended for long-term use. `MailCookies` must be a Cookie Header String, such as `key1=value1; key2=value2`. The driver can generate and persist a new `Authorization`, and can fall back to password login when token refresh fails. |
+| Authorization           | `Authorization`                       | Fastest setup. Fill in the value after `Basic `. Do not include `Basic` itself. You may need to update it manually after it expires or refresh fails.                                                                                     |
+| Mail cookies fast login | `MailCookies`                         | Use cookies from `mail.10086.cn`. `MailCookies` must be a Cookie Header String and contain valid key-value pairs; `Os_SSo_Sid` and `RMKEY` are used for fast login.                                                                       |
+
+`Username`, `Password`, and `MailCookies` are not required when `Authorization` is valid, even if an old frontend marks them as required.
+
+When using password login fallback, `MailCookies`, `Username`, and `Password` must be filled together.
+
+`MailCookies` should look like the value of an HTTP `Cookie` request header: `key1=value1; key2=value2; key3=value3`.
+:::
+
 ::: zh-CN
-::: warning
-只需要填写 Basic 空格后面开始的内容，**不要包含 Basic**！
+驱动支持三种鉴权方式。除非需要密码登录作为回退，否则选择其中一种即可。
+
+| 方式                 | 需要填写的字段                        | 说明                                                                                                                                                                                   |
+| -------------------- | ------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 密码登录回退         | `MailCookies`、`Username`、`Password` | 推荐长期使用。`MailCookies` 必须是 Cookie Header String 格式，例如 `key1=value1; key2=value2`。驱动可以生成并持久化新的 `Authorization`，当刷新 Token 失败时也可以回退到账号密码登录。 |
+| Authorization        | `Authorization`                       | 配置最快。只填写 `Basic ` 后面的内容，不要包含 `Basic` 本身；过期或刷新失败后可能需要手动更新。                                                                                        |
+| 邮箱 Cookie 快速登录 | `MailCookies`                         | 使用 `mail.10086.cn` 的 Cookie。`MailCookies` 必须是 Cookie Header String 格式，并包含有效键值对；快速登录会用到 `Os_SSo_Sid` 和 `RMKEY`。                                             |
+
+当 `Authorization` 有效时，`Username`、`Password`、`MailCookies` 实际不必填写；如果旧前端显示必填，以驱动校验逻辑为准。
+
+使用密码登录回退时，`MailCookies`、`Username`、`Password` 必须同时填写。
+
+`MailCookies` 应该像 HTTP 请求头里的 `Cookie` 值：`key1=value1; key2=value2; key3=value3`。
 :::
 
 ## Type { lang="en" }
@@ -79,83 +131,65 @@ Fill in the content starting after the Basic and a space, **do not include Basic
 ## 类型 { lang="zh-CN" }
 
 ::: en
-OpenList currently supports 4 types of cloud storage:
+OpenList currently supports four 139Yun storage types. `personal_new` is the default.
 
-- Personal New: New API
-  - Note: The account has been migrated to a new personal cloud by the end of 2024
-  - Use the PUT method to directly connect to EOS multipart uploads
-- Family: My Family -> Family Files
-  - Limit: The Family Cloud does not support copying, moving, or renaming folders, and files cannot be uploaded to the root directory
-  - Use the POST method to resumable uploads
-- Group: Shared Group
-  - Limit: Shared groups do not support copying and uploading
-- Personal: The old personal cloud, which is a thing of the past. If you're still using it, please contact customer service to upgrade.
+| Type           | Use for                   | Root folder ID when empty                                           | Cloud ID     | Notes                                                                                        |
+| -------------- | ------------------------- | ------------------------------------------------------------------- | ------------ | -------------------------------------------------------------------------------------------- |
+| `personal_new` | New personal cloud        | `/`                                                                 | Not required | New API. Uses direct EOS multipart upload.                                                   |
+| `family`       | My Family -> Family Files | Automatically tries to save `data.path` without the `root:/` prefix | Required     | Uses Family Cloud APIs. If auto-detection fails, fill the folder ID manually.                |
+| `group`        | Shared group              | Uses `Cloud ID`                                                     | Required     | For groups created by others, manually fill the folder ID to avoid first-level folder loops. |
+| `personal`     | Old personal cloud        | `root`                                                              | Not required | Legacy personal cloud. Most accounts have been migrated to `personal_new`.                   |
 
 :::
 
 ::: zh-CN
-OpenList 目前支持挂载 4 种类型：
+OpenList 目前支持四种中国移动云盘类型，默认类型是 `personal_new`。
 
-- 新个人云：新 API
-  - 注意：移动已于 2024 年底迁移账号到新的个人云
-  - 新的个人云使用 PUT 方法直连 EOS 分片上传
-- 家庭云：我的家庭 -> 家庭文件
-  - 限制：家庭云不支持复制、移动、重命名文件夹，根目录无法上传文件
-  - 家庭云使用 POST 方法断点续传
-- 共享群：共享群组
-  - 限制：共享群组不支持复制、上传
-- 个人云：旧的个人云，已成为历史，如果还在使用，请联系客服升级
+| 类型           | 适用场景             | 根文件夹 ID 为空时                             | Cloud ID | 说明                                                                  |
+| -------------- | -------------------- | ---------------------------------------------- | -------- | --------------------------------------------------------------------- |
+| `personal_new` | 新个人云             | `/`                                            | 不需要   | 新 API，使用 EOS 直连分片上传。                                       |
+| `family`       | 我的家庭 -> 家庭文件 | 自动尝试保存去掉 `root:/` 前缀后的 `data.path` | 必填     | 使用家庭云接口。自动获取失败时需要手动填写文件夹 ID。                 |
+| `group`        | 共享群组             | 使用 `Cloud ID`                                | 必填     | 如果挂载别人创建的共享群，建议手动填写文件夹 ID，避免一级文件夹循环。 |
+| `personal`     | 旧个人云             | `root`                                         | 不需要   | 旧个人云。多数账号已经迁移到 `personal_new`。                         |
 
+:::
+
+::: en
+::: warning
+After changing `Type`, clear or update `Root folder ID`, then save the storage again.
+:::
+:::
+
+::: zh-CN
+::: warning
+更改 `Type` 后，请清空或重新填写 `Root folder ID`，再保存存储。
+:::
 :::
 
 ## Root folder ID { lang="en" }
 
-## 根文件夹ID { lang="zh-CN" }
+## 根文件夹 ID { lang="zh-CN" }
 
 ::: en
-Specifies the directory to be mounted.
+`Root folder ID` specifies the mounted directory.
+
+- `personal_new`: use `/` for the root. For a subfolder, use the folder ID from `parentFileId` or `currentCatalogID`.
+- `family`: leave empty to let OpenList try to read `data.path` automatically. When filling manually, remove the `root:/` or `root:` prefix.
+- `group`: leave empty only when mounting your own group root. For a subfolder or a group created by others, fill the folder ID manually.
+- `personal`: use `root` for the legacy root.
+
+Do not add extra `/` around subfolder IDs. For example, use `abc123`, not `/abc123`.
 :::
 
 ::: zh-CN
-文件夹ID，用于指定挂载的目录。
-:::
+`Root folder ID` 用于指定要挂载的目录。
 
-::: en
-::: warning
-Please remember to clear or change this Root folder ID after changed the Type!
-:::
+- `personal_new`：根目录填写 `/`。挂载子文件夹时，使用 `parentFileId` 或 `currentCatalogID` 中的文件夹 ID。
+- `family`：留空时 OpenList 会尝试自动读取 `data.path`。手动填写时，需要去掉 `root:/` 或 `root:` 前缀。
+- `group`：只有挂载自己共享群根目录时适合留空。挂载子文件夹或别人创建的共享群时，建议手动填写文件夹 ID。
+- `personal`：旧个人云根目录使用 `root`。
 
-::: zh-CN
-::: warning
-更改类型后请记得清空或修改根文件夹ID！
-:::
-
-::: en
-
-- Personal New: `/`. It can be left blank and it will be filled in automatically.
-  - If you want to list a folder separately, please enter the folder ID.
-- Family: If the root directory is empty, all files are filed.
-  - If you want to list a folder separately, please enter the folder ID.
-- Group: If the root directory is empty, the group ID will be automatically filled. It is recommended to enter the folder ID that you manually obtained.
-  - If you want to list a folder separately, please enter the folder ID.
-  - Note: If you want to mount a group created by others, be sure to fill in the folder ID that you manually obtained, otherwise there will be an infinite loop in the first-level folder.
-- Personal: `root`. It can be left blank and it will be filled in automatically. All will be listed, covering 18 items (check it yourself). Normal files are in **My Folder**.
-  - If the write folder ID is listed in the normal root folder.
-
-:::
-
-::: zh-CN
-
-- 新个人云：`/`，可以为空会自动填写，会将所有的都列出来
-  - 若想挂载单独某个文件夹，请填写文件夹ID。
-- 家庭云：根目录为空就是全部文件
-  - 若想挂载单独某个文件夹，请填写文件夹ID。
-- 共享群：为空会自动填写群组ID，建议填写手动获取的文件夹ID
-  - 若想挂载单独某个文件夹，请填写文件夹ID。
-  - 注意：如果想挂载别人创建的共享群，请务必填写手动获取的文件夹ID，否则会出现在一级文件夹无限循环的问题。
-- 个人云：`root`，可以为空会自动填写，会将所有的都列出来，涵盖18项(自行查看)，正常文件在 **我的文件夹** 这个里面
-  - 如果写文件夹ID列出的是正常的根目录文件夹
-
+手动填写子文件夹 ID 时不要额外添加 `/`。例如填写 `abc123`，不要填写 `/abc123`。
 :::
 
 ## Cloud ID { lang="en" }
@@ -163,148 +197,151 @@ Please remember to clear or change this Root folder ID after changed the Type!
 ## Cloud ID { lang="zh-CN" }
 
 ::: en
-Personal cloud does not need to fill in, **Family / Group cloud is dedicated**.
+`Cloud ID` is required only for `family` and `group`.
 
-- Family: family ID, **cannot be empty**
-- Group: group ID, **cannot be empty**
-
-:::
-
-::: zh-CN
-用于区分特殊存储的ID。个人云不需要填写，**家庭云、共享群专用**。
-
-- 家庭云：家庭云ID，**不能为空**
-- 共享群：群组ID，**不能为空**
-
-:::
-
-## Custom upload part size { lang="en" }
-
-## 自定义上传分片大小 { lang="zh-CN" }
-
-::: en
-The upload part size (bytes) can be customized by the user, and if there is a performance issue, please adjust it yourself. Set '0' to 100 MB by default.
-
-- The current upload part size on the web is 20 MB (20971520).
-- The [EOS documentation](https://ecloud.10086.cn/op-help-center/api/article/40933) used by the new version of the Personal Cloud states that "objects larger than > 5 GB cannot be uploaded", so the upload part size should not exceed 5 GB.
+- `family`: family cloud ID.
+- `group`: group ID.
+- `personal_new` and `personal`: leave empty.
 
 :::
 
 ::: zh-CN
-可供用户自定义分片大小，单位是字节，如果出现性能问题请自行调整，设置 `0` 默认为 100 MB。
+`Cloud ID` 只在 `family` 和 `group` 类型下需要填写。
 
-- 目前网页端的分片大小为 20 MB（20971520）。
-- 新版个人云所使用的 [EOS 文档](https://ecloud.10086.cn/op-help-center/api/article/40933) 中说明“无法上传大小大于> 5 GB 的对象”，故分片大小不要超过 5 GB。
+- `family`：家庭云 ID。
+- `group`：群组 ID。
+- `personal_new` 和 `personal`：留空。
 
 :::
 
-## Other { lang="en" }
+## User domain ID { lang="en" }
 
-## 其他 { lang="zh-CN" }
+## 用户域 ID { lang="zh-CN" }
+
+::: en
+`UserDomainID` is the `ud_id` value in cookies. It is optional for mounting and is mainly used to show disk usage in storage details. If it is empty, file listing and downloads can still work, but capacity statistics are unavailable.
+:::
+
+::: zh-CN
+`UserDomainID` 是 Cookie 中的 `ud_id`。它不是挂载必填项，主要用于在存储详情中显示容量统计。留空时仍可列目录和下载，但无法显示容量信息。
+:::
+
+## Advanced options { lang="en" }
+
+## 高级选项 { lang="zh-CN" }
 
 ::: en
 
-- Other information is taken from the request, which has changed from cookie to obtaining `Authorization`
-  - The new personal cloud can be obtained in another way. See the picture example of [Personal new](#personal-new)
-- If you can't find the load on the bottom of the request information, go to the top `on the top of the upper row, marked the purple highlight
+- `Custom upload part size`: upload part size in bytes. `0` means automatic. The driver uses `100 MB` by default and increases it to `512 MB` for files larger than `30 GB`.
+- `Report real size`: enabled by default. For old personal, family, and group uploads, it reports the real file size to the upstream API.
+- `Use large thumbnail`: disabled by default. Enable it to prefer large image thumbnails when the new personal cloud API returns them.
 
 :::
 
 ::: zh-CN
 
-- 其他信息取自请求，已经从获取cookie改变成获取`Authorization`
-  - 新个人云可以通过另外的方式获取详情查看[新个人云](#新个人云)的图片示例
-- 请求信息中底部找不到`载荷`，就去顶部`上面一排`，标记了紫色高亮
+- `Custom upload part size`：上传分片大小，单位为字节。`0` 表示自动。驱动默认使用 `100 MB`，文件大于 `30 GB` 时会自动使用 `512 MB`。
+- `Report real size`：默认开启。旧个人云、家庭云、共享群上传时，会向上游接口上报真实文件大小。
+- `Use large thumbnail`：默认关闭。开启后，新个人云接口返回大图缩略图时会优先使用大图。
 
 :::
 
-### Search keywords { lang="en" }
+## Proxy Range { lang="en" }
 
-### 搜索关键词 { lang="zh-CN" }
+## 代理 Range { lang="zh-CN" }
 
 ::: en
-Pay attention to the keywords, use it below to get **`authorization`**, **Root folder ID** and **Cloud ID**
+`Proxy Range` is enabled by default in the driver, but it only takes effect after enabling `Web Proxy` or `WebDAV Native Proxy`.
 
-- Personal Cloud: **getDisk**
-- Family Cloud: **queryContentList**
-- Personal New: hcy/file/**list**
-  - Headers - `Authorization`
-  - Payload - `parentFileId`: folder ID
-- Family: **queryContentList**
-  - Headers - `Authorization`
-  - Payload - `cloudID`: family ID
-  - Payload - `catalogID`: folder ID
-  - Response - `data.path`: full folder ID
-- Group: **queryGroupContentList**
-  - Headers - `Authorization`
-  - Payload - `groupID`: group ID
-  - Payload - `path`: full folder ID
-- Personal: **getDisk**
-
+Enable proxy mode when a player or downloader cannot handle the upstream 302 link correctly, for example when video playback fails, seeking fails, or resumable downloads do not work.
 :::
+
 ::: zh-CN
-注意查看关键词，获取 **`Authorization`** 、**根文件夹ID**、**Cloud ID**时使用
+驱动默认开启 `Proxy Range`，但它需要配合 `Web 代理` 或 `WebDAV 本地代理` 才会生效。
 
-- 新个人云：hcy/file/**list**
-  - 标头 - `Authorization`
-  - 载荷 - `parentFileId`：文件夹ID
-- 家庭云：**queryContentList**
-  - 标头 - `Authorization`
-  - 载荷 - `cloudID`：家庭云ID
-  - 载荷 - `catalogID`：文件夹ID
-  - 响应 - `data.path`：完整文件夹ID
-- 共享群：**queryGroupContentList**
-  - 标头 - `Authorization`
-  - 载荷 - `groupID`：群组ID
-  - 载荷 - `path`：完整文件夹ID
-- 个人云：**getDisk**
-
+当播放器或下载器不能正确处理上游 302 链接时，建议开启代理模式，例如视频无法播放、拖动进度失败或不支持断点续传。
 :::
 
-### Personal new: { lang="en" }
+## Search keywords { lang="en" }
 
-### 新个人云： { lang="zh-CN" }
+## 搜索关键词 { lang="zh-CN" }
 
 ::: en
-Choose one of the following methods to find `Authorization` and `Folder ID`
+Use browser DevTools to find the fields below.
+
+| Need                      | Where to search                                     | Field                                                          |
+| ------------------------- | --------------------------------------------------- | -------------------------------------------------------------- |
+| `Authorization`           | Network request headers on `yun.139.com`            | `Authorization: Basic ...`; copy only the value after `Basic ` |
+| New personal folder ID    | `hcy/file/list` request, or browser storage         | `parentFileId` or `currentCatalogID`                           |
+| Family Cloud ID           | `queryContentList` request payload                  | `cloudID`                                                      |
+| Family folder ID          | `queryContentList` response                         | `data.path`; remove `root:/` or `root:` when filling manually  |
+| Group ID                  | `queryGroupContentList` request payload             | `groupID`                                                      |
+| Group folder ID           | `queryGroupContentList` request payload or response | `path` or folder ID                                            |
+| Legacy personal folder ID | `getDisk` request or response                       | `catalogID`                                                    |
+| `UserDomainID`            | Browser cookies                                     | `ud_id`                                                        |
+
+In Firefox, cookies and local storage can be easier to find in DevTools -> Storage.
+:::
+
+::: zh-CN
+使用浏览器开发者工具查找以下字段。
+
+| 需要获取          | 查找位置                               | 字段                                                 |
+| ----------------- | -------------------------------------- | ---------------------------------------------------- |
+| `Authorization`   | `yun.139.com` 的网络请求标头           | `Authorization: Basic ...`；只复制 `Basic ` 后面的值 |
+| 新个人云文件夹 ID | `hcy/file/list` 请求，或浏览器存储     | `parentFileId` 或 `currentCatalogID`                 |
+| 家庭云 ID         | `queryContentList` 请求载荷            | `cloudID`                                            |
+| 家庭云文件夹 ID   | `queryContentList` 响应                | `data.path`；手动填写时去掉 `root:/` 或 `root:`      |
+| 共享群 ID         | `queryGroupContentList` 请求载荷       | `groupID`                                            |
+| 共享群文件夹 ID   | `queryGroupContentList` 请求载荷或响应 | `path` 或文件夹 ID                                   |
+| 旧个人云文件夹 ID | `getDisk` 请求或响应                   | `catalogID`                                          |
+| `UserDomainID`    | 浏览器 Cookie                          | `ud_id`                                              |
+
+Firefox 中可以在开发者工具 -> 存储中查看 Cookie 和本地存储，通常更容易找到 `authorization`、`ud_id` 和 `currentCatalogID`。
+:::
+
+### Personal new { lang="en" }
+
+### 新个人云 { lang="zh-CN" }
+
+::: en
+Choose one of the following methods to find `Authorization` and folder ID.
 
 ![](/img/drivers/139/new_personal.png)
 ![](/img/drivers/139/139_new_au.png)
 
-If you want to view the directory ID of a subfolder, please enter the subfolder first and then view the new request, otherwise the old directory ID will still be displayed.
+If you want the folder ID of a subfolder, enter that subfolder first and then inspect the new request or storage value. Otherwise, the old folder ID may still be displayed.
 :::
 
 ::: zh-CN
-以下查找 `Authorization` 和 `子文件夹ID` 的方法二选一
+以下方法可用于查找 `Authorization` 和文件夹 ID。
 
 ![](/img/drivers/139/new_personal.png)
 ![](/img/drivers/139/139_new_au.png)
 
-如果你想查看子文件夹的目录ID，请先进入子文件夹后在查看新的请求，否则还是之前旧的目录ID
-<br/>
+如果要查看子文件夹 ID，请先进入该子文件夹，再查看新的请求或存储值，否则看到的可能仍是之前的文件夹 ID。
 :::
 
-### Personal cloud: { lang="en" }
+### Personal cloud { lang="en" }
 
-### 个人云： { lang="zh-CN" }
+### 个人云 { lang="zh-CN" }
 
 ![](/img/drivers/139/other-personal.png)
 ![](/img/drivers/139/ch-personal.png)
 
-### Family cloud: { lang="en" }
+### Family cloud { lang="en" }
 
-### 家庭云： { lang="zh-CN" }
+### 家庭云 { lang="zh-CN" }
 
 ::: en
 ![](/img/drivers/139/other-family.png)
 ![](/img/drivers/139/ch-family.png)
 
 ::: details Teaching video
-Although the video is V2 version, the way to obtain the directory ID and the cloud ID is the same.
+Although the video is for V2, the method for obtaining folder ID and Cloud ID is still similar.
 
 **<https://www.bilibili.com/video/BV1US4y1w79a>**
-
-From the previous way to get cookies, now replaced it with `Authorization`，You can see the [Fill in the Example](#openlist-fill-in-examples) tutorial below
+:::
 :::
 
 ::: zh-CN
@@ -312,56 +349,51 @@ From the previous way to get cookies, now replaced it with `Authorization`，You
 ![](/img/drivers/139/ch-family.png)
 
 ::: details 详细教学视频
-虽然视频是V2版本，但是获取目录ID 和 Cloud ID的方式一样，
+虽然视频是 V2 版本，但获取目录 ID 和 Cloud ID 的方式仍然类似。
 
 **<https://www.bilibili.com/video/BV1US4y1w79a>**
-
-现在已经从获取Cookie的方式变成了获取`Authorization`，获取方式可以看下方[填写示例](#填写示例)教程
+:::
 :::
 
-### OpenList fill in examples: { lang="en" }
+### OpenList fill in examples { lang="en" }
 
-### OpenList挂载填写示例： { lang="zh-CN" }
+### OpenList 挂载填写示例 { lang="zh-CN" }
 
 ::: en
 
-- **`Authorization`Just fill in the content of the start after the basic space**
-- The new personal cloud folder ID will automatically change after you enter the folder. Just open whichever folder you need, and then get the value of `currentCatalogID`<sup>Figure_3</sup>
-  ![](/img/drivers/139/add-personal.png)
-  ![](/img/drivers/139/add-family.png)
-  ![](/img/drivers/139/add_new_personal.png)
+- `Authorization`: fill in only the content after `Basic `.
+- New personal folder ID: enter the target folder first, then use the current `currentCatalogID`.
 
+![](/img/drivers/139/add-personal.png)
+![](/img/drivers/139/add-family.png)
+![](/img/drivers/139/add_new_personal.png)
 :::
+
 ::: zh-CN
 
-- **`Authorization`只需要填写Basic空格后面开始的内容**
-- 新个人云文件夹ID，你进入文件夹后会自动变化，你需要哪个文件夹ID就进入哪个文件夹，然后获取`currentCatalogID`<sup>图3</sup>的值就可以
-  ![](/img/drivers/139/add-personal.png)
-  ![](/img/drivers/139/add-family.png)
-  ![](/img/drivers/139/add_new_personal.png)
+- `Authorization`：只填写 `Basic ` 后面的内容。
+- 新个人云文件夹 ID：先进入目标文件夹，再使用当前的 `currentCatalogID`。
 
+![](/img/drivers/139/add-personal.png)
+![](/img/drivers/139/add-family.png)
+![](/img/drivers/139/add_new_personal.png)
 :::
 
-### 默认使用的下载方式 { lang="zh-CN" }
+## Download method { lang="en" }
 
-### The default download method used { lang="en" }
+## 下载方式 { lang="zh-CN" }
 
 ::: en
+The default download method is 302 redirection. If a player such as PotPlayer cannot play through 302, switch that mount to proxy mode or mount it through WebDAV with `WebDAV Native Proxy`.
 
 ```mermaid
 ---
 title: Which download method is used by default?
 ---
 flowchart TB
-    style a1 fill:#bbf,stroke:#f66,stroke-width:2px,color:#fff
-    style a2 fill:#ff7575,stroke:#333,stroke-width:4px
-    subgraph ide1 [ ]
-    a1
-    end
-    a1[302]:::someclass====|default|a2[user equipment]
-    classDef someclass fill:#f96
-    c1[local proxy]-.alternative.->a2[user equipment]
-    b1[Download proxy URL]-.alternative.->a2[user equipment]
+    a1[302 redirect]====|default|a2[user device]
+    c1[local proxy]-.alternative.->a2
+    b1[download proxy URL]-.alternative.->a2
     click a1 "../drivers/common.html#webdav-policy"
     click b1 "../drivers/common.html#webdav-policy"
     click c1 "../drivers/common.html#webdav-policy"
@@ -370,21 +402,16 @@ flowchart TB
 :::
 
 ::: zh-CN
+默认下载方式是 302 跳转。如果 PotPlayer 等播放器无法通过 302 播放，可以将该挂载切换为代理模式，或通过启用 `WebDAV 本地代理` 的 WebDAV 挂载播放。
 
 ```mermaid
 ---
 title: 默认使用的哪种下载方式？
 ---
 flowchart TB
-    style a1 fill:#bbf,stroke:#f66,stroke-width:2px,color:#fff
-    style a2 fill:#ff7575,stroke:#333,stroke-width:4px
-    subgraph ide1 [ ]
-    a1
-    end
-    a1[302]:::someclass====|默认|a2[用户设备]
-    classDef someclass fill:#f96
-    c1[本机代理]-.备选.->a2[用户设备]
-    b1[代理URL]-.备选.->a2[用户设备]
+    a1[302 跳转]====|默认|a2[用户设备]
+    c1[本机代理]-.备选.->a2
+    b1[代理 URL]-.备选.->a2
     click a1 "../drivers/common.html#webdav-策略"
     click b1 "../drivers/common.html#webdav-策略"
     click c1 "../drivers/common.html#webdav-策略"

--- a/pages/guide/drivers/139.md
+++ b/pages/guide/drivers/139.md
@@ -22,29 +22,25 @@ Cloud disk address: **<https://yun.139.com/>**
 云盘地址：**<https://yun.139.com/>**
 :::
 
-:::: en
+:::en
 ::: warning
 The OpenList version must be greater than `v3.41.0` to use this tutorial.
 :::
-::::
 
-:::: zh-CN
+:::zh-CN
 ::: warning
 OpenList 版本必须大于 `v3.41.0` 才能使用本教程。
 :::
-::::
 
-:::: en
+:::en
 ::: tip
 Most parameters can be obtained from browser DevTools. See [Search keywords](#search-keywords).
 :::
-::::
 
-:::: zh-CN
+:::zh-CN
 ::: tip
 大部分参数可通过浏览器开发者工具获取。请参考[搜索关键词](#搜索关键词)。
 :::
-::::
 
 ## Quick start { lang="en" }
 
@@ -68,6 +64,7 @@ For long-term use, use the new personal cloud with password login fallback. This
 If you only want to mount quickly, you can fill only `Authorization`: log in to <https://yun.139.com/>, find a `hcy/file/list` request in DevTools -> Network, copy the request header `Authorization`, and paste only the content after `Basic `.
 
 If you want to mount a subfolder, enter that folder on the 139Yun website first, then use the current `parentFileId` or `currentCatalogID` as `Root folder ID`.
+
 :::
 
 ::: zh-CN
@@ -88,6 +85,7 @@ If you want to mount a subfolder, enter that folder on the 139Yun website first,
 如果只是想快速挂载，也可以只填 `Authorization`：登录 <https://yun.139.com/>，在开发者工具 -> 网络中找到 `hcy/file/list` 请求，复制请求标头里的 `Authorization`，并且只粘贴 `Basic ` 后面的内容。
 
 如果要挂载子文件夹，请先在移动云盘网页端进入该文件夹，再把当前的 `parentFileId` 或 `currentCatalogID` 填到 `Root folder ID`。
+
 :::
 
 ## Authentication { lang="en" }
@@ -108,6 +106,7 @@ The driver supports three authentication methods. Use only one method unless you
 When using password login fallback, `MailCookies`, `Username`, and `Password` must be filled together.
 
 `MailCookies` should look like the value of an HTTP `Cookie` request header: `key1=value1; key2=value2; key3=value3`.
+
 :::
 
 ::: zh-CN
@@ -124,6 +123,7 @@ When using password login fallback, `MailCookies`, `Username`, and `Password` mu
 使用密码登录回退时，`MailCookies`、`Username`、`Password` 必须同时填写。
 
 `MailCookies` 应该像 HTTP 请求头里的 `Cookie` 值：`key1=value1; key2=value2; key3=value3`。
+
 :::
 
 ## Type { lang="en" }
@@ -154,17 +154,15 @@ OpenList 目前支持四种中国移动云盘类型，默认类型是 `personal_
 
 :::
 
-:::: en
+:::en
 ::: warning
 After changing `Type`, clear or update `Root folder ID`, then save the storage again.
 :::
-::::
 
-:::: zh-CN
+:::zh-CN
 ::: warning
 更改 `Type` 后，请清空或重新填写 `Root folder ID`，再保存存储。
 :::
-::::
 
 ## Root folder ID { lang="en" }
 
@@ -190,6 +188,7 @@ Do not add extra `/` around subfolder IDs. For example, use `abc123`, not `/abc1
 - `personal`：旧个人云根目录使用 `root`。
 
 手动填写子文件夹 ID 时不要额外添加 `/`。例如填写 `abc123`，不要填写 `/abc123`。
+
 :::
 
 ## Cloud ID { lang="en" }
@@ -220,10 +219,12 @@ Do not add extra `/` around subfolder IDs. For example, use `abc123`, not `/abc1
 
 ::: en
 `UserDomainID` is the `ud_id` value in cookies. It is optional for mounting and is mainly used to show disk usage in storage details. If it is empty, file listing and downloads can still work, but capacity statistics are unavailable.
+
 :::
 
 ::: zh-CN
 `UserDomainID` 是 Cookie 中的 `ud_id`。它不是挂载必填项，主要用于在存储详情中显示容量统计。留空时仍可列目录和下载，但无法显示容量信息。
+
 :::
 
 ## Advanced options { lang="en" }
@@ -254,12 +255,14 @@ Do not add extra `/` around subfolder IDs. For example, use `abc123`, not `/abc1
 `Proxy Range` is enabled by default in the driver, but it only takes effect after enabling `Web Proxy` or `WebDAV Native Proxy`.
 
 Enable proxy mode when a player or downloader cannot handle the upstream 302 link correctly, for example when video playback fails, seeking fails, or resumable downloads do not work.
+
 :::
 
 ::: zh-CN
 驱动默认开启 `Proxy Range`，但它需要配合 `Web 代理` 或 `WebDAV 本地代理` 才会生效。
 
 当播放器或下载器不能正确处理上游 302 链接时，建议开启代理模式，例如视频无法播放、拖动进度失败或不支持断点续传。
+
 :::
 
 ## Search keywords { lang="en" }
@@ -281,6 +284,7 @@ Use browser DevTools to find the fields below.
 | `UserDomainID`            | Browser cookies                                     | `ud_id`                                                        |
 
 In Firefox, cookies and local storage can be easier to find in DevTools -> Storage.
+
 :::
 
 ::: zh-CN
@@ -298,6 +302,7 @@ In Firefox, cookies and local storage can be easier to find in DevTools -> Stora
 | `UserDomainID`    | 浏览器 Cookie                          | `ud_id`                                              |
 
 Firefox 中可以在开发者工具 -> 存储中查看 Cookie 和本地存储，通常更容易找到 `Authorization`、`ud_id` 和 `currentCatalogID`。
+
 :::
 
 ### Personal new { lang="en" }
@@ -311,6 +316,7 @@ Choose one of the following methods to find `Authorization` and folder ID.
 ![](/img/drivers/139/139_new_au.png)
 
 If you want the folder ID of a subfolder, enter that subfolder first and then inspect the new request or storage value. Otherwise, the old folder ID may still be displayed.
+
 :::
 
 ::: zh-CN
@@ -320,6 +326,7 @@ If you want the folder ID of a subfolder, enter that subfolder first and then in
 ![](/img/drivers/139/139_new_au.png)
 
 如果要查看子文件夹 ID，请先进入该子文件夹，再查看新的请求或存储值，否则看到的可能仍是之前的文件夹 ID。
+
 :::
 
 ### Personal cloud { lang="en" }
@@ -333,7 +340,7 @@ If you want the folder ID of a subfolder, enter that subfolder first and then in
 
 ### 家庭云 { lang="zh-CN" }
 
-:::: en
+:::en
 ![](/img/drivers/139/other-family.png)
 ![](/img/drivers/139/ch-family.png)
 
@@ -342,9 +349,8 @@ Although the video is for V2, the method for obtaining folder ID and Cloud ID is
 
 **<https://www.bilibili.com/video/BV1US4y1w79a>**
 :::
-::::
 
-:::: zh-CN
+:::zh-CN
 ![](/img/drivers/139/other-family.png)
 ![](/img/drivers/139/ch-family.png)
 
@@ -353,7 +359,6 @@ Although the video is for V2, the method for obtaining folder ID and Cloud ID is
 
 **<https://www.bilibili.com/video/BV1US4y1w79a>**
 :::
-::::
 
 ### OpenList fill in examples { lang="en" }
 


### PR DESCRIPTION
## Summary

- Rework the 139Yun driver guide around a beginner-friendly quick start.
- Document long-term authentication with `MailCookies` + `Username` + `Password`, including Cookie Header String format from `mail.10086.cn`.
- Clarify `Authorization`, storage types, root folder ID defaults, `Cloud ID`, `UserDomainID`, advanced options, and 302/proxy playback behavior.
- Address common feedback from discussion #283, including Firefox storage lookup, `ud_id`, root ID slash handling, and PotPlayer/WebDAV proxy guidance.

## Verification

- `pnpm exec prettier --check pages/guide/drivers/139.md`
- `git diff --check -- pages\guide\drivers\139.md`
- `pnpm run build:spa`