### PR TITLE
docs(s3): clarify download transfer modes

### DIFF
--- a/pages/guide/advanced/s3.md
+++ b/pages/guide/advanced/s3.md
@@ -83,16 +83,22 @@ This function is to map OpenList as the S3 protocol. You can use the [S3 client]
 
 ::: en
 
-1. After mapping OpenList as S3 service, **All download links are transferred to the local agent**, whether it is 302 or open the Proxy URL link download
-2. Currently only supports the use of client operations `List`,` get`, `put`,` del`, other operations are not supported yet
-3. Currently only supports the use of the `S3 Client` to operate, Mount S3 to the `OpenList Object Storage` temporarily unavailable
+1. For ordinary object downloads, the transfer mode depends on the storage and proxy settings:
+   - If proxying is not required and the storage provides a direct download URL, OpenList may return an HTTP 302 redirect to the storage provider.
+   - If **Web Proxy** is enabled for the target storage, or another driver or proxy rule requires proxying, OpenList serves the response body through the local server.
+2. A direct redirect saves OpenList bandwidth, but the S3 client must follow a cross-host redirect and accept the provider URL's access requirements. Server relay uses OpenList bandwidth and is a safer starting point for clients that cannot use the direct provider redirect. For repository tools such as restic or rustic, enable **Web Proxy** unless direct mode has been verified.
+3. Currently only supports the use of client operations `List`, `get`, `put`, `del`, other operations are not supported yet
+4. Currently only supports the use of the `S3 Client` to operate, Mount S3 to the `OpenList Object Storage` temporarily unavailable
 
 :::
 ::: zh-CN
 
-1. 将OpenList映射为S3服务后， **所有下载链接均为本地代理进行中转**，无论是否是302还是开启了代理URL链接下载
-2. 目前仅支持使用客户端 `获取列表`、`下载`、`上传`、`删除` 操作，其它操作暂未支持
-3. 目前仅支持使用`S3客户端`来进行操作，挂载到OpenList对象存储暂时无法使用
+1. 对于普通对象下载，传输方式取决于存储和代理设置：
+   - 如果不需要代理，并且存储提供了直链下载地址，OpenList 可能返回 HTTP 302，将客户端重定向到存储提供商。
+   - 如果为目标存储启用了 **Web 代理**，或者驱动及其它代理规则要求使用代理，OpenList 会通过本地服务器中转响应内容。
+2. 直链重定向可以节省 OpenList 的带宽，但 S3 客户端必须支持跨域名重定向，并满足存储提供商下载地址的访问要求。服务器中转会占用 OpenList 的带宽，但对于无法使用存储直链重定向的客户端是更稳妥的起点。使用 restic 或 rustic 等仓库工具时，除非已经验证直链模式可用，否则建议启用 **Web 代理**。
+3. 目前仅支持使用客户端 `获取列表`、`下载`、`上传`、`删除` 操作，其它操作暂未支持
+4. 目前仅支持使用`S3客户端`来进行操作，挂载到OpenList对象存储暂时无法使用
 
 :::
 


### PR DESCRIPTION
## Description / 描述

- Clarify that ordinary S3 object downloads may use an HTTP 302 redirect when proxying is not required and the storage provides a direct URL.
- Explain when OpenList relays the response through the local server, including the target storage's **Web Proxy** setting.
- Document the bandwidth and client-compatibility tradeoff, with a conservative recommendation for repository tools such as restic and rustic.
- Keep the English and Chinese guidance aligned.

## Motivation and Context / 背景

The existing guide says that every S3 download is relayed locally. Current OpenList behavior can instead redirect an eligible ordinary object download to the storage provider, so operators cannot reliably choose between direct and relayed transfers from the current documentation.

Relates to OpenListTeam/OpenList#2796

## Validation / 验证

- `prettier --check pages/guide/advanced/s3.md` — passed with the repository-pinned Prettier 3.6.2.
- `git diff --check` — passed.
- `NODE_OPTIONS='--max-old-space-size=8192' valaxy build --ssg` — passed in Git Bash; the generated S3 page contains both updated language sections and the existing section anchors.
- `pnpm format:check` — the modified S3 page passes, but the repository-wide command reports 179 pre-existing files outside this change.
- The native Windows `pnpm build` wrapper reaches `build:ssg` but cannot parse its POSIX-style `NODE_OPTIONS=...` assignment; the equivalent SSG command above completed successfully.

## Checklist / 检查清单

- [x] I have read the [CONTRIBUTING](https://github.com/OpenListTeam/OpenList-Docs/blob/main/CONTRIBUTING.md) document.
      我已阅读 [CONTRIBUTING](https://github.com/OpenListTeam/OpenList-Docs/blob/main/CONTRIBUTING.md) 文档。
- [x] I have formatted my code or documentation with [prettier](https://prettier.io/) or another appropriate formatter.
      我已使用 [prettier](https://prettier.io/) 或其它适当的格式化工具格式化提交的文档。
- [x] I have updated all supported languages (including Chinese and English) for documentation.
      我已为所有支持语言（包括中文和英文）更新文档内容。
- [x] I have verified that the written documentation is properly formatted and builds without page syntax errors.
      我已确认文档格式正确，并且可以构建且不存在页面语法错误。
- [x] I have updated the related repository as needed.
      我已按需更新相关仓库。
  - [x] [OpenList](https://github.com/OpenListTeam/OpenList/issues/2796) #2796
  - [ ] [OpenList-Frontend](https://github.com/OpenListTeam/OpenList-Frontend) — not applicable
