### PR TITLE
docs(local): document PDF thumbnails on macOS

### DIFF
--- a/pages/guide/drivers/local.md
+++ b/pages/guide/drivers/local.md
@@ -58,6 +58,34 @@ You need to use the `ffmpeg` tool to add.
 需要使用 `ffmpeg` 工具来添加.
 :::
 
+## Local storage PDF thumbnail on macOS { lang="en" }
+
+## macOS 本地存储 PDF 缩略图 { lang="zh-CN" }
+
+::: en
+On macOS, the Local storage driver can generate thumbnails from the first page of PDF files using the system Quick Look tool.
+
+To enable this feature:
+
+1. Enable `Thumbnail`.
+2. Enable `PDF thumbnail`.
+3. It is recommended to configure `Thumb cache folder` to avoid rendering the same PDF repeatedly.
+
+This feature is disabled by default and is only available when OpenList runs on macOS. Rendering is performed on cache misses and may consume additional CPU and memory.
+:::
+
+::: zh-CN
+在 macOS 上，本机存储驱动可以调用系统 Quick Look 工具，为 PDF 文件生成首页缩略图。
+
+启用方法：
+
+1. 开启 `缩略图（Thumbnail）`。
+2. 开启 `PDF 缩略图（PDF thumbnail）`。
+3. 建议配置 `缩略图缓存目录（Thumb cache folder）`，避免重复渲染同一 PDF 文件。
+
+该功能默认关闭，并且仅在 OpenList 运行于 macOS 时可用。缓存未命中时会执行渲染，可能额外消耗 CPU 和内存。
+:::
+
 ## Recycle bin path { lang="en" }
 
 ## 回收站路径 { lang="zh-CN" }


### PR DESCRIPTION
## Description / 描述Documents the macOS PDF thumbnail option introduced in OpenListTeam/OpenList#3017.- Explains that both `Thumbnail` and `PDF thumbnail` must be enabled- Notes that the feature is macOS-only and disabled by default- Recommends configuring `Thumb cache folder`- Documents the additional CPU and memory usage on cache misses## Checklist / 检查清单- [x] The updated page follows the existing bilingual documentation structure.- [x] `pages/guide/drivers/local.md` passes Prettier checks.- [x] The full SSG build succeeds with pnpm 10.12.1.