### PR TITLE
docs(aliyundrive): explain callback concurrency

### DIFF
--- a/pages/guide/drivers/aliyundrive_open.md
+++ b/pages/guide/drivers/aliyundrive_open.md
@@ -259,7 +259,9 @@ Open Platform URL: <https://www.alipan.com/developer/f>
 
 13. In `Internal Upload`, select whether to enable internal upload (optional), default is off. See [Configuration Instructions/Internal Upload](#_3-2-7-internal-upload).
 
-14. Click the `Add` button to complete adding AliYun Drive.
+14. Set `Callback Concurrency` when OpenList will proxy downloads (optional; default: `1`). See [Configuration Instructions/Callback Concurrency](#_3-2-8-callback-concurrency).
+
+15. Click the `Add` button to complete adding AliYun Drive.
 
 :::
 
@@ -315,7 +317,9 @@ Open Platform URL: <https://www.alipan.com/developer/f>
 
 13. 在`内部上传`中，选择是否启用内部上传（可选），默认是关闭。见[配置说明/内部上传](#_3-2-7-内部上传)。
 
-14. 点击`添加`按钮，完成阿里云盘的添加。
+14. OpenList 需要代理下载时，可设置`回调并发数`（可选，默认为 `1`）。见[配置说明/回调并发数](#_3-2-8-回调并发数)。
+
+15. 点击`添加`按钮，完成阿里云盘的添加。
 
 :::
 
@@ -496,6 +500,22 @@ If the server where OpenList is deployed is an AliYun ECS in the Beijing region,
 
 - **内部上传**非北京地区的阿里云ECS可以使用吗？不能，因为阿里云盘在使用北京地区的对象存储
 
+:::
+
+#### 3.2.8. Callback Concurrency { lang="en" }
+
+#### 3.2.8. 回调并发数 { lang="zh-CN" }
+
+::: en
+`Callback Concurrency` limits the number of active AliYun Drive callback downloads opened by OpenList in proxy mode. The default is `1`; missing, zero, or negative values are treated as `1`. Direct `302` downloads do not use this limit.
+
+Mounts that resolve to the same AliYun Drive user share callback capacity. If those mounts have different settings, OpenList uses the smallest positive value. When the limit is full, a new download waits for up to one second. A verified AliYun Drive callback-concurrency rejection is attempted up to three times with exponential jitter starting at 200 ms. If capacity is still unavailable, an S3 proxy download returns the standard `SlowDown` error with HTTP `503` so compatible clients can retry.
+:::
+
+::: zh-CN
+`回调并发数`限制 OpenList 在代理模式下打开的阿里云盘回调下载数量。默认值为 `1`；未设置、零或负数均按 `1` 处理。直接 `302` 下载不受此限制。
+
+解析为同一阿里云盘用户的多个挂载会共享回调容量；如果这些挂载的设置不同，OpenList 使用其中最小的正数值。并发已满时，新下载最多等待一秒。对于已确认的阿里云盘回调并发拒绝，OpenList 最多尝试三次，并从 200 毫秒开始进行带抖动的指数退避。如果容量仍不可用，S3 代理下载会返回标准 `SlowDown` 错误和 HTTP `503`，以便兼容的客户端重试。
 :::
 
 ## 4. Other Instructions { lang="en" }


### PR DESCRIPTION
## Description / 描述

Document the new Aliyun Drive Open Callback Concurrency setting in English and Chinese, including:

- proxy-only applicability and the default value of 1;
- conservative sharing by Aliyun user identity and minimum-value resolution across mounts;
- the one-second admission wait and three-attempt provider-capacity retry bound;
- standard S3 SlowDown / HTTP 503 behavior after capacity is exhausted.

新增阿里云盘 Open“回调并发数”的中英文说明，包括代理模式适用范围、默认值 1、同一用户挂载共享最小配置、一秒准入等待、三次容量重试，以及容量耗尽后的 S3 SlowDown / HTTP 503 行为。

## Motivation and Context / 背景

Operators need the configuration and retry behavior documented alongside the implementation for Aliyun callback concurrency failures.

Relates to OpenListTeam/OpenList#2969

## Checklist / 检查清单

- [x] I have read the [CONTRIBUTING](https://github.com/OpenListTeam/OpenList-Docs/blob/main/CONTRIBUTING.md) document.
      我已阅读 [CONTRIBUTING](https://github.com/OpenListTeam/OpenList-Docs/blob/main/CONTRIBUTING.md) 文档。
- [x] I have formatted my code or documentation with [prettier](https://prettier.io/) or other appropriate formatter.
      我已使用 [prettier](https://prettier.io/) 或其他适当的格式化工具格式化提交的代码或文档。
- [x] I have updated all supported languages (including Chinese and English) for documentation. (If it's needed)
      我已为所有支持语言（包括中文和英文）更新文档内容。 (若适用)
- [x] I have verified that the written documentation or code is properly formatted, with no syntax errors, spelling mistakes.
      我已确认编写的文档或代码格式正确, 无语法错误, 拼写错误。
- [x] I have updated the repository accordingly (If it's needed).
      我已相应更新了相关仓库（若适用）。
  - [x] [OpenList](https://github.com/OpenListTeam/OpenList) #3071
  - [ ] [OpenList-Frontend](https://github.com/OpenListTeam/OpenList-Frontend) Not required; the field is metadata-driven.

## Testing / 测试

- `pnpm exec prettier --check pages/guide/drivers/aliyundrive_open.md`
- `pnpm exec valaxy build --ssg`

The SSG build completed successfully. It emitted existing warnings for external version-source timeouts, an icon set, and the Badge component.

## AI Disclosure / AI 使用声明

Codex assisted with documentation drafting, Chinese/English translation, formatting, and review. Commit attribution is included. The related OpenList implementation remains under review in OpenListTeam/OpenList#3071.